### PR TITLE
Increase receive timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Increased receive timeout for WS polling
 
 ## [0.3.9] - 2024-09-21
 ### Added

--- a/src/nice_go/_ws_client.py
+++ b/src/nice_go/_ws_client.py
@@ -225,7 +225,7 @@ class WebSocketClient:
         if self.ws is None or self.ws.closed:
             error_msg = "WebSocket connection is closed"
             raise WebSocketError(error_msg)
-        msg = await self.ws.receive(timeout=60.0)
+        msg = await self.ws.receive(timeout=300.0)
         if msg.type == aiohttp.WSMsgType.TEXT:
             await self.received_message(msg.data)
         elif msg.type == aiohttp.WSMsgType.ERROR:


### PR DESCRIPTION
## Description

Increase the timeout for receiving in WS polling. This should hopefully reduce the amount of times it goes unavailable in Home Assistant.

## Checklist

- [ ] Tests covering the new functionality have been added
- [x] Documentation has been updated OR the change is too minor to be documented
- [x] Changes are listed in the `CHANGELOG.md` OR changes are insignificant

## Summary by Sourcery

Increase the receive timeout for WebSocket polling from 60 seconds to 300 seconds to address unavailability issues in Home Assistant.

Bug Fixes:
- Increased the receive timeout for WebSocket polling to reduce unavailability issues in Home Assistant.

Documentation:
- Updated the CHANGELOG.md to reflect the increase in receive timeout for WebSocket polling.