### PR TITLE
Raise AuthFailedError on expired token during WebSocket reconnect

### DIFF
--- a/src/nice_go/_util.py
+++ b/src/nice_go/_util.py
@@ -26,3 +26,21 @@ async def get_request_template(
         for key, value in arguments.items():
             template = template.replace(f"${key}", value)
     return json.loads(template)
+
+
+def find_unauthorized_error(
+    errors: list[dict[str, Any]],
+) -> dict[str, Any] | None:
+    """Find the first error indicating an expired/invalid ID token, if any.
+
+    Args:
+        errors: A list of GraphQL-style error dictionaries.
+
+    Returns:
+        The first error with `errorType` set to `UnauthorizedException`, or
+            `None` if no such error is present.
+    """
+    for error in errors:
+        if error.get("errorType") == "UnauthorizedException":
+            return error
+    return None

--- a/src/nice_go/_ws_client.py
+++ b/src/nice_go/_ws_client.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING, Any, Callable, NamedTuple
 import aiohttp
 
 from nice_go._exceptions import AuthFailedError, ReconnectWebSocketError, WebSocketError
-from nice_go._util import get_request_template
+from nice_go._util import find_unauthorized_error, get_request_template
 
 if TYPE_CHECKING:
     import yarl
@@ -160,9 +160,9 @@ class WebSocketClient:
             _LOGGER.debug("Received message: %s", data)
             if data["type"] == "connection_error":
                 errors = data.get("payload", {}).get("errors", [])
-                if errors and errors[0].get("errorType") == "UnauthorizedException":
+                if unauthorized := find_unauthorized_error(errors):
                     raise AuthFailedError(
-                        errors[0].get("message", "Token has expired"),
+                        unauthorized.get("message", "Token has expired"),
                     )
             if data["type"] != "connection_ack":
                 msg = f'Expected connection_ack, but received {data["type"]}'

--- a/src/nice_go/_ws_client.py
+++ b/src/nice_go/_ws_client.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING, Any, Callable, NamedTuple
 
 import aiohttp
 
-from nice_go._exceptions import ReconnectWebSocketError, WebSocketError
+from nice_go._exceptions import AuthFailedError, ReconnectWebSocketError, WebSocketError
 from nice_go._util import get_request_template
 
 if TYPE_CHECKING:
@@ -144,6 +144,8 @@ class WebSocketClient:
         """Initialize the WebSocket connection.
 
         Raises:
+            AuthFailedError: If the connection was rejected because the ID token
+                has expired.
             WebSocketError: If the WebSocket connection is closed or an error occurs.
         """
         if self.ws is None or self.ws.closed:
@@ -156,6 +158,12 @@ class WebSocketClient:
             message = await self.ws.receive(timeout=10)
             data = json.loads(message.data)
             _LOGGER.debug("Received message: %s", data)
+            if data["type"] == "connection_error":
+                errors = data.get("payload", {}).get("errors", [])
+                if errors and errors[0].get("errorType") == "UnauthorizedException":
+                    raise AuthFailedError(
+                        errors[0].get("message", "Token has expired"),
+                    )
             if data["type"] != "connection_ack":
                 msg = f'Expected connection_ack, but received {data["type"]}'
                 raise WebSocketError(

--- a/src/nice_go/nice_go_api.py
+++ b/src/nice_go/nice_go_api.py
@@ -40,7 +40,7 @@ from nice_go._exceptions import (
     ReconnectWebSocketError,
     WebSocketError,
 )
-from nice_go._util import get_request_template
+from nice_go._util import find_unauthorized_error, get_request_template
 from nice_go._ws_client import WebSocketClient
 
 T = TypeVar("T")
@@ -388,10 +388,9 @@ class NiceGOApi:
         """
 
         if errors := response.get("errors"):
-            error = errors[0]
-            if error["errorType"] == "UnauthorizedException":
-                raise AuthFailedError(error)
-            raise ApiError(error)
+            if unauthorized := find_unauthorized_error(errors):
+                raise AuthFailedError(unauthorized)
+            raise ApiError(errors[0])
 
     @retry(
         wait=wait_random_exponential(multiplier=1, min=1, max=10),

--- a/tests/test_ws_client.py
+++ b/tests/test_ws_client.py
@@ -90,6 +90,58 @@ async def test_ws_init_connection_error_other(mock_ws_client: WebSocketClient) -
         await mock_ws_client.init()
 
 
+async def test_ws_init_connection_error_empty_errors(
+    mock_ws_client: WebSocketClient,
+) -> None:
+    assert mock_ws_client.ws is not None
+    assert isinstance(mock_ws_client.ws, AsyncMock)
+    mock_ws_client.ws.receive = AsyncMock()
+    mock_ws_client.ws.receive.return_value = MagicMock(
+        data=json.dumps({"type": "connection_error", "payload": {"errors": []}}),
+    )
+    with pytest.raises(WebSocketError):
+        await mock_ws_client.init()
+
+
+async def test_ws_init_connection_error_missing_payload(
+    mock_ws_client: WebSocketClient,
+) -> None:
+    assert mock_ws_client.ws is not None
+    assert isinstance(mock_ws_client.ws, AsyncMock)
+    mock_ws_client.ws.receive = AsyncMock()
+    mock_ws_client.ws.receive.return_value = MagicMock(
+        data=json.dumps({"type": "connection_error"}),
+    )
+    with pytest.raises(WebSocketError):
+        await mock_ws_client.init()
+
+
+async def test_ws_init_token_expired_not_first_error(
+    mock_ws_client: WebSocketClient,
+) -> None:
+    assert mock_ws_client.ws is not None
+    assert isinstance(mock_ws_client.ws, AsyncMock)
+    mock_ws_client.ws.receive = AsyncMock()
+    mock_ws_client.ws.receive.return_value = MagicMock(
+        data=json.dumps(
+            {
+                "type": "connection_error",
+                "payload": {
+                    "errors": [
+                        {"errorType": "SomeOtherError", "message": "Other error."},
+                        {
+                            "errorType": "UnauthorizedException",
+                            "message": "Token has expired.",
+                        },
+                    ],
+                },
+            },
+        ),
+    )
+    with pytest.raises(AuthFailedError, match="Token has expired."):
+        await mock_ws_client.init()
+
+
 async def test_ws_init_timeout(mock_ws_client: WebSocketClient) -> None:
     assert mock_ws_client.ws is not None
     assert isinstance(mock_ws_client.ws, AsyncMock)

--- a/tests/test_ws_client.py
+++ b/tests/test_ws_client.py
@@ -11,7 +11,7 @@ import pytest
 import yarl
 
 from nice_go import WebSocketError
-from nice_go._exceptions import ReconnectWebSocketError
+from nice_go._exceptions import AuthFailedError, ReconnectWebSocketError
 from nice_go._ws_client import EventListener, WebSocketClient
 
 
@@ -46,6 +46,45 @@ async def test_ws_init_unexpected_type(mock_ws_client: WebSocketClient) -> None:
     mock_ws_client.ws.receive = AsyncMock()
     mock_ws_client.ws.receive.return_value = MagicMock(
         data=json.dumps({"type": "unexpected_type"}),
+    )
+    with pytest.raises(WebSocketError):
+        await mock_ws_client.init()
+
+
+async def test_ws_init_token_expired(mock_ws_client: WebSocketClient) -> None:
+    assert mock_ws_client.ws is not None
+    assert isinstance(mock_ws_client.ws, AsyncMock)
+    mock_ws_client.ws.receive = AsyncMock()
+    mock_ws_client.ws.receive.return_value = MagicMock(
+        data=json.dumps(
+            {
+                "type": "connection_error",
+                "payload": {
+                    "errors": [
+                        {
+                            "errorType": "UnauthorizedException",
+                            "message": "Token has expired.",
+                        },
+                    ],
+                },
+            },
+        ),
+    )
+    with pytest.raises(AuthFailedError, match="Token has expired."):
+        await mock_ws_client.init()
+
+
+async def test_ws_init_connection_error_other(mock_ws_client: WebSocketClient) -> None:
+    assert mock_ws_client.ws is not None
+    assert isinstance(mock_ws_client.ws, AsyncMock)
+    mock_ws_client.ws.receive = AsyncMock()
+    mock_ws_client.ws.receive.return_value = MagicMock(
+        data=json.dumps(
+            {
+                "type": "connection_error",
+                "payload": {"errors": [{"errorType": "SomeOtherError"}]},
+            },
+        ),
     )
     with pytest.raises(WebSocketError):
         await mock_ws_client.init()


### PR DESCRIPTION
## Problem

Home Assistant users report the Nice G.O. integration silently stopping updates after roughly 1–7 days, only recovering after a full config entry reload or HA restart: home-assistant/core#126370

Debug logs from that issue show the WebSocket connection dying with `WebSocket connection closed`, retrying, and then receiving:

```
Received message: {'payload': {'errors': [{'errorType': 'UnauthorizedException', 'message': 'Token has expired.', 'errorCode': 401}]}, 'type': 'connection_error'}
```

## Root cause

`WebSocketClient.init()` only recognizes `connection_ack`. Any other message type — including `connection_error` sent by AppSync when the ID token has expired — falls into the generic branch and raises a plain `WebSocketError`. `NiceGOApi.connect()`'s `@retry` decorator retries on `WebSocketError`, but nothing refreshes `id_token` in between retries, so it retries forever with the same expired token. The `_check_response_errors` helper already distinguishes `UnauthorizedException` this way for the HTTP GraphQL calls (`get_all_barriers`, `open_barrier`, etc.), but the WebSocket handshake path never got the same treatment.

## Fix

`init()` now inspects `connection_error` payloads for `UnauthorizedException` and raises `AuthFailedError` instead of `WebSocketError`. `AuthFailedError` isn't in `connect()`'s retry list, so it propagates immediately instead of being silently retried — letting the caller (e.g. Home Assistant's coordinator) refresh the token and reconnect, rather than hammering AppSync with a dead token indefinitely.

## Testing

- Added `test_ws_init_token_expired` and `test_ws_init_connection_error_other` to `tests/test_ws_client.py`.
- `poetry run pytest` — 105 passed, 100% coverage.
- `poetry run ruff check` / `ruff format --check` / `mypy` — clean.

## Follow-up

Home Assistant's `nice_go` coordinator (`client_listen`) would need a small change once this ships, to catch `AuthFailedError` there and call `authenticate_refresh` before retrying `connect()` — happy to help with that PR once this is released.

## Summary by Sourcery

Handle expired or invalid ID tokens during WebSocket initialization by surfacing an authentication failure instead of endlessly retrying.

Bug Fixes:
- Stop infinite WebSocket reconnect loops when the server reports an expired ID token by raising AuthFailedError instead of WebSocketError.
- Ensure non-authentication connection errors during WebSocket initialization still surface as generic WebSocketError.

Enhancements:
- Introduce a shared helper to locate UnauthorizedException errors in GraphQL-style error lists and reuse it for both HTTP and WebSocket paths.
- Align HTTP GraphQL error handling to use the shared unauthorized error helper while preserving existing ApiError behavior for other errors.

Tests:
- Add WebSocket client tests covering connection_error messages, including expired token, other error types, empty errors list, and missing payload.