### PR TITLE
Drop caret upper bounds on runtime dependencies

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -4236,4 +4236,4 @@ test = ["big-O", "importlib-resources ; python_version < \"3.9\"", "jaraco.funct
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9.1, <4.0"
-content-hash = "64f01f8367320660f9f2be2a90778d534db4cb02f64ee49be20dfa749d8d87ea"
+content-hash = "73815f1d0bd1e3471623c27486cde34ad838e71c2a9f7423b9bafa6ff62200b4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,11 +32,11 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.9.1, <4.0"
-aiohttp = "^3.9.5"
+aiohttp = ">=3.9.5"
 aiobotocore = ">=2.13.1,<4.0.0"
-yarl = "^1.9.4"
-pycognito = "^2024.5.1"
-tenacity = "^8.5.0"
+yarl = ">=1.9.4"
+pycognito = ">=2024.5.1"
+tenacity = ">=8.5.0"
 
 [tool.poetry.group.dev.dependencies]
 mkdocstrings = {version = ">=0.23", extras = ["python"]}


### PR DESCRIPTION
## Description

Drop the caret (`^`) upper bounds on the runtime dependencies (`aiohttp`, `yarl`, `pycognito`, `tenacity`), replacing them with lower-bound-only `>=` constraints.

A caret constraint expands to an implicit `< next-major` upper bound. For a library that is too limiting for consumers that must resolve a single version set across many packages. Home Assistant, for example, can't pair `nice-go` with another integration that needs a newer major of a shared dependency — concretely, it currently can't adopt `tenacity` 9.x (required by another dependency) because `nice-go` caps it at `<9`. The preference is to rely on consumers' test suites to catch real incompatibilities with new versions rather than pre-emptively capping.

I verified that the latest `tenacity` (9.1.4) still provides every symbol `nice-go` imports — `retry`, `retry_base`, `retry_if_exception_type`, `wait_random_exponential`, `before_sleep_log`, `RetryCallState` — so lifting that cap is safe.

`poetry.lock` was refreshed (content-hash only; no dependency versions changed).

## Checklist

- [ ] Tests covering the new functionality have been added
- [x] Documentation has been updated OR the change is too minor to be documented
- [x] Changes are listed in the `CHANGELOG.md` OR changes are insignificant

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_016huRs96kGdQbNQopXseC4H

## Summary by Sourcery

Relax runtime dependency version constraints to remove implicit upper bounds while keeping existing minimum supported versions.

Enhancements:
- Allow newer versions of aiohttp, yarl, pycognito, and tenacity by switching to lower-bound-only dependency constraints in pyproject.toml.

Build:
- Refresh Poetry lockfile metadata to reflect the updated dependency constraints without changing resolved versions.