### PR TITLE
Fix deprecated `asyncio.iscoroutinefunction` warning

### DIFF
--- a/src/nice_go/nice_go_api.py
+++ b/src/nice_go/nice_go_api.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import inspect
 import json
 import logging
 from typing import Any, Callable, Coroutine, TypeVar
@@ -165,7 +166,7 @@ class NiceGOApi:
             ...
             >>> remove_listener = api.listen("data", on_data)
         """
-        if not asyncio.iscoroutinefunction(coro):
+        if not inspect.iscoroutinefunction(coro):
             msg = "The decorated function must be a coroutine"
             raise TypeError(msg)
 


### PR DESCRIPTION
## Description

Fixes the warning about the deprecated `asyncio.iscoroutinefunction` usage in `nice_go_api.py`

## Checklist

- [ ] Tests covering the new functionality have been added
- [x] Documentation has been updated OR the change is too minor to be documented
- [x] Changes are listed in the `CHANGELOG.md` OR changes are insignificant

## Summary by Sourcery

Bug Fixes:
- Replace the deprecated coroutine detection API to eliminate warnings when registering event listeners.