### PR TITLE
Switch to PyPI trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: PyPI
     permissions:
+      contents: write
       id-token: write
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,13 +6,17 @@ on:
 
 jobs:
   build-and-publish:
+    name: Build and publish package
     runs-on: ubuntu-latest
+    environment: PyPI
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/python-poetry-env
-      - name: Publish to pypi
-        run: |
-          poetry config pypi-token.pypi ${{ secrets.PYPI_TOKEN }}
-          poetry publish --build --no-interaction
+      - name: Build package
+        run: poetry build --no-interaction
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@release/v1
       - name: Deploy docs
         run: poetry run mkdocs gh-deploy --force


### PR DESCRIPTION
## Description

Switch to using [`pypa/gh-action-pypi-publish`](https://github.com/pypa/gh-action-pypi-publish) to satisfy the checks found [here](https://github.com/home-assistant/core/pull/179747#issuecomment-5372284552)

## Checklist

- [ ] Tests covering the new functionality have been added
- [ ] Documentation has been updated OR the change is too minor to be documented
- [ ] Changes are listed in the `CHANGELOG.md` OR changes are insignificant

## Summary by Sourcery

Adopt PyPI trusted publishing for automated package releases.

Enhancements:
- Replace token-based PyPI publishing with trusted publishing through the PyPI GitHub Action.
- Separate package building from publishing and configure the release workflow with the required PyPI environment and permissions.

CI:
- Grant the release workflow OIDC identity-token and repository-content permissions for trusted publishing.