### PR TITLE
Only run tests and actionlint if truly needed

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ jobs:
     outputs:
       run_tests: ${{ steps.changes.outputs.run_tests }}
       run_actionlint: ${{ steps.changes.outputs.run_actionlint }}
+      run_docs: ${{ steps.changes.outputs.run_docs }}
     steps:
       - uses: actions/checkout@v7
       - name: Gather changed files

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,29 @@ on:
       - "main"
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    name: Gather changed files
+    outputs:
+      run_tests: ${{ steps.changes.outputs.run_tests }}
+      run_actionlint: ${{ steps.changes.outputs.run_actionlint }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Gather changed files
+        id: changes
+        uses: dorny/paths-filter@v2
+        with:
+          filters: |
+            run_tests:
+              - 'src/**'
+              - 'tests/**'
+            run_actionlint:
+              - '.github/workflows/**'
+
   actionlint:
+    name: Check workflow files
+    needs: changes
+    if: needs.changes.outputs.run_actionlint == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -39,6 +61,11 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
+    needs:
+      - changes
+      - lint-cruft
+      - pre-commit
+    if: needs.changes.outputs.run_tests == 'true'
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/python-poetry-env
@@ -52,6 +79,8 @@ jobs:
           path: coverage.xml
 
   docs:
+    needs: [changes, test]
+    if: needs.changes.outputs.run_tests == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,8 +23,13 @@ jobs:
             run_tests:
               - 'src/**'
               - 'tests/**'
+              - 'pyproject.toml'
+              - 'poetry.lock'
             run_actionlint:
               - '.github/workflows/**'
+            run_docs:
+              - 'docs/**'
+              - 'mkdocs.yml'
 
   actionlint:
     name: Check workflow files
@@ -80,7 +85,7 @@ jobs:
 
   docs:
     needs: [changes, test]
-    if: needs.changes.outputs.run_tests == 'true'
+    if: needs.changes.outputs.run_docs == 'true' || needs.changes.outputs.run_tests == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
## Description

Improves workflows to only run certain jobs if they're really needed

## Checklist

- [ ] Tests covering the new functionality have been added
- [ ] Documentation has been updated OR the change is too minor to be documented
- [ ] Changes are listed in the `CHANGELOG.md` OR changes are insignificant

## Summary by Sourcery

Run CI checks only when changes affect the corresponding workflows, source, tests, or documentation.

Enhancements:
- Conditionally run workflow validation, test, and documentation jobs based on the files changed in the pull request.

CI:
- Add a change-detection job to control whether actionlint, tests, and documentation checks are needed.